### PR TITLE
Changes interface for fn.Last

### DIFF
--- a/last.go
+++ b/last.go
@@ -1,12 +1,13 @@
 package fn
 
 // Grabs last item in array
-// Will return error if array is empty
-func Last[T any](arr []T) (*T, error) {
+// Will return empty value and false if array is empty
+func Last[T any](arr []T) (T, bool) {
 	if len(arr) == 0 {
-		return nil, &EmptyArrayError{}
+		var zero T
+		return zero, false
 	}
 
 	val := arr[len(arr)-1]
-	return &val, nil
+	return val, true
 }

--- a/last_test.go
+++ b/last_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestLast(t *testing.T) {
 	arr := []int{1, 2, 3}
-	val, err := fn.Last(arr)
-	require.Equal(t, *val, 3)
-	require.Nil(t, err)
+	val, ok := fn.Last(arr)
+	require.Equal(t, val, 3)
+	require.True(t, ok)
 }
 
-func TestLastError(t *testing.T) {
+func TestLastEmpty(t *testing.T) {
 	arr := []int{}
-	val, err := fn.Last(arr)
-	require.Nil(t, val)
-	require.Equal(t, err, &fn.EmptyArrayError{})
+	val, ok := fn.Last(arr)
+	require.False(t, ok)
+	require.Equal(t, val, 0)
 }


### PR DESCRIPTION
Updates `fn.Last` to follow more idiomatic go patterns

Before
```
last, err := fn.Last(arr)
if err == nil {
    useLast(*last)
}
```

Now
```
last, ok := fn.Last(arr)
if ok {
   useLast(last)  
}
```

This now works more like maps `val, ok := someMap[key]`


